### PR TITLE
Removed excessive delay

### DIFF
--- a/src/porsmo/pomodoro.rs
+++ b/src/porsmo/pomodoro.rs
@@ -97,7 +97,6 @@ pub fn pomodoro(
             format!("Round: {}", pomo.session()),
         )?;
 
-        thread::sleep(Duration::from_millis(100));
     }
 
     Ok(pomo.elapsed())
@@ -124,7 +123,6 @@ fn skip_prompt(
             }
         }
 
-        thread::sleep(Duration::from_millis(100));
     }
 }
 
@@ -167,7 +165,6 @@ fn start_excess_counting(
             format!("Round: {}", session),
         )?;
 
-        thread::sleep(Duration::from_millis(100));
     }
 
     Ok((st.elapsed(), false))

--- a/src/porsmo/stopwatch.rs
+++ b/src/porsmo/stopwatch.rs
@@ -45,7 +45,6 @@ pub fn default_stopwatch_loop(
 
         update(&st)?;
 
-        thread::sleep(Duration::from_millis(100));
     }
 
     Ok(st.elapsed())

--- a/src/porsmo/timer.rs
+++ b/src/porsmo/timer.rs
@@ -60,7 +60,6 @@ pub fn timer(time: Duration) -> Result<Duration> {
             "",
         )?;
 
-        thread::sleep(Duration::from_millis(100));
     }
 
     Ok(counter_ended_at)


### PR DESCRIPTION
After short time keyboard stop working.

```
let event = event::read().with_context(|| "Failed to read event")?; 
```

Can produce ton of terminal events (like mouse movement). With 100ms delay, events are pile up and prevent keyboard from responding.

Bug was introduced by 5013e8f