### PR TITLE
On quitting pomodoro mode, output total time spent working and resting

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,9 @@ pub enum CounterMode {
     Pomodoro {
         #[clap(subcommand, name = "mode")]
         mode: PomoMode,
+        ///Display a message after quitting the pomodoro timer
+        #[arg(short, name = "exitmessage")]
+        exitmessage: bool,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,14 +24,16 @@ fn main() -> Result<()> {
     let args = Cli::parse();
     let mut terminal = TerminalHandler::new()?;
     let stdout = terminal.stdout();
-    let exitmessage = match args.mode {
+    let exitmessagestring = match args.mode {
         Some(CounterMode::Stopwatch) => StopwatchUI::default().run_ui(stdout)?,
         Some(CounterMode::Timer { target }) => TimerUI::new(target).run_ui(stdout)?,
         Some(CounterMode::Pomodoro {
             mode: PomoMode::Short,
+            exitmessage: _,
         }) => PomodoroUI::new(PomodoroConfig::short()).run_ui(stdout)?,
         Some(CounterMode::Pomodoro {
             mode: PomoMode::Long,
+            exitmessage: _,
         }) => PomodoroUI::new(PomodoroConfig::long()).run_ui(stdout)?,
         Some(CounterMode::Pomodoro {
             mode:
@@ -40,11 +42,20 @@ fn main() -> Result<()> {
                     break_time,
                     long_break,
                 },
+            exitmessage: _,
         }) => PomodoroUI::new(PomodoroConfig::new(work_time, break_time, long_break))
             .run_ui(stdout)?,
         None => PomodoroUI::new(PomodoroConfig::short()).run_ui(stdout)?,
     };
-    terminal.set_exit_message(exitmessage.clone());
+    if matches!(
+        args.mode,
+        Some(CounterMode::Pomodoro {
+            mode: _,
+            exitmessage: true
+        })
+    ) {
+        terminal.set_exit_message(exitmessagestring.clone());
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ fn main() -> Result<()> {
             .run_ui(stdout)?,
         None => PomodoroUI::new(PomodoroConfig::short()).run_ui(stdout)?,
     };
+    drop(terminal);
     if matches!(
         args.mode,
         Some(CounterMode::Pomodoro {
@@ -54,7 +55,7 @@ fn main() -> Result<()> {
             exitmessage: true
         })
     ) {
-        terminal.set_exit_message(exitmessagestring.clone());
+        println!("{}", exitmessagestring);
     }
     Ok(())
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,14 +1,16 @@
 use crate::{error::PorsmoError, prelude::*};
 use crossterm::{
-    cursor::{MoveTo, Hide, Show},
+    cursor::{Hide, MoveTo, Show},
     execute,
-    style::Color,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-    terminal::{Clear, ClearType},
+    style::{Color, Print},
+    terminal::{
+        disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen,
+        LeaveAlternateScreen,
+    },
 };
 use std::io::{stdout, Stdout};
 
-pub struct TerminalHandler(Stdout);
+pub struct TerminalHandler(Stdout, String);
 
 impl TerminalHandler {
     pub fn new() -> Result<Self> {
@@ -24,11 +26,15 @@ impl TerminalHandler {
         )
         .map_err(PorsmoError::FailedInitialization)?;
 
-        Ok(Self(stdout))
+        Ok(Self(stdout, String::new()))
     }
 
     pub fn stdout(&mut self) -> &mut Stdout {
         &mut self.0
+    }
+
+    pub fn set_exit_message(&mut self, s: String) {
+        self.1 = s;
     }
 }
 
@@ -40,6 +46,7 @@ impl Drop for TerminalHandler {
             Clear(ClearType::All),
             Show,
             LeaveAlternateScreen,
+            Print(self.1.clone())
         )
         .expect("Failed to reset screen");
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -2,7 +2,7 @@ use crate::{error::PorsmoError, prelude::*};
 use crossterm::{
     cursor::{Hide, MoveTo, Show},
     execute,
-    style::{Color, Print},
+    style::Color,
     terminal::{
         disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen,
         LeaveAlternateScreen,
@@ -10,7 +10,7 @@ use crossterm::{
 };
 use std::io::{stdout, Stdout};
 
-pub struct TerminalHandler(Stdout, String);
+pub struct TerminalHandler(Stdout);
 
 impl TerminalHandler {
     pub fn new() -> Result<Self> {
@@ -26,29 +26,19 @@ impl TerminalHandler {
         )
         .map_err(PorsmoError::FailedInitialization)?;
 
-        Ok(Self(stdout, String::new()))
+        Ok(Self(stdout))
     }
 
     pub fn stdout(&mut self) -> &mut Stdout {
         &mut self.0
-    }
-
-    pub fn set_exit_message(&mut self, s: String) {
-        self.1 = s;
     }
 }
 
 impl Drop for TerminalHandler {
     fn drop(&mut self) {
         disable_raw_mode().expect("Failed to disable raw mode");
-        execute!(
-            stdout(),
-            Clear(ClearType::All),
-            Show,
-            LeaveAlternateScreen,
-            Print(self.1.clone())
-        )
-        .expect("Failed to reset screen");
+        execute!(stdout(), Clear(ClearType::All), Show, LeaveAlternateScreen,)
+            .expect("Failed to reset screen");
     }
 }
 


### PR DESCRIPTION
Hello! 
I implemented the request from #15 , specifically the second version proposed [there](https://github.com/ColorCookie-dev/porsmo/issues/15#issuecomment-2093229952): after the timer is closed, the pomodoro mode optionally displays the total time spent working and on break, respectively.
It measures the time during which the pomodoro timer advances, i.e. excess time is counted, skips and pauses are not counted (neither the time spent in the skip ui-mode).

To use it, invoke it with th '-e' flag, e.g. "porsmo pomodoro -e short"; I was unfamiliar with clap before today, this what I came up with, although I am not overly happy with it. 

(This is my first ever pull request to a public repo; feel free to tell me where I could do better.)